### PR TITLE
 #167780949 Fix validation on user name

### DIFF
--- a/src/middleware/validation.js
+++ b/src/middleware/validation.js
@@ -13,7 +13,6 @@ export default {
   signupValidation(req, res, next) {
     const userSchema = Joi.object().keys({
       firstName: Joi.string()
-        .alphanum()
         .min(2)
         .required()
         .regex(/^[A-Za-z]*$/)
@@ -22,13 +21,10 @@ export default {
             // eslint-disable-next-line default-case
             switch (err.type) {
               case 'string.regex.base':
-                err.message = 'First name cannot begin with a number';
+                err.message = 'First name cannot contain number or special characters';
                 break;
               case 'any.required':
                 err.message = 'First name is required';
-                break;
-              case 'string.alphanum':
-                err.message = 'First name must contain only alpha-numeric characters';
                 break;
               case 'string.min':
                 err.message = 'First name must be at least 2 characters long';
@@ -41,7 +37,6 @@ export default {
           return errors;
         }),
       lastName: Joi.string()
-        .alphanum()
         .min(2)
         .required()
         .regex(/^[A-Za-z]*$/)
@@ -50,13 +45,10 @@ export default {
             // eslint-disable-next-line default-case
             switch (err.type) {
               case 'string.regex.base':
-                err.message = 'Last name cannot begin with a number';
+                err.message = 'Last name cannot contain number or special characters';
                 break;
               case 'any.required':
                 err.message = 'Last name is required';
-                break;
-              case 'string.alphanum':
-                err.message = 'Last name must contain only alpha numeric characters';
                 break;
               case 'string.min':
                 err.message = 'Last name must be at least 2 characters long';
@@ -72,7 +64,7 @@ export default {
         .alphanum()
         .min(2)
         .required()
-        .regex(/^[A-Za-z]*$/)
+        .regex(/^[A-Za-z]+[A-Z-a-z-0-9]$/)
         .error((errors) => {
           errors.forEach((err) => {
             // eslint-disable-next-line default-case

--- a/src/middleware/validation.js
+++ b/src/middleware/validation.js
@@ -64,7 +64,7 @@ export default {
         .alphanum()
         .min(2)
         .required()
-        .regex(/^[A-Za-z]+[A-Z-a-z-0-9]$/)
+        .regex(/^[A-Za-z]+[A-Z-a-z-0-9]*$/)
         .error((errors) => {
           errors.forEach((err) => {
             // eslint-disable-next-line default-case

--- a/src/tests/user.test.js
+++ b/src/tests/user.test.js
@@ -18,7 +18,8 @@ describe('POST /api/v1/users', () => {
         expect(res).have.status(400);
         expect(res).to.be.an('object');
         expect(res.body).to.have.keys('status', 'error');
-        expect(res.body.error).to.deep.equal('First name must contain only alpha-numeric characters');
+        expect(res.body.error)
+          .to.deep.equal('First name cannot contain number or special characters');
         expect(res.body.status).to.deep.equal('failed');
         done();
       });
@@ -35,7 +36,8 @@ describe('POST /api/v1/users', () => {
         expect(res).have.status(400);
         expect(res).to.be.an('object');
         expect(res.body).to.have.keys('status', 'error');
-        expect(res.body.error).to.deep.equal('First name cannot begin with a number');
+        expect(res.body.error)
+          .to.deep.equal('First name cannot contain number or special characters');
         expect(res.body.status).to.deep.equal('failed');
         done();
       });
@@ -105,7 +107,7 @@ describe('POST /api/v1/users', () => {
         expect(res.body).to.have.keys('status', 'error');
         expect(res.body.error)
           .to.deep
-          .equal('Last name must contain only alpha numeric characters');
+          .equal('Last name cannot contain number or special characters');
         expect(res.body.status).to.deep.equal('failed');
         done();
       });
@@ -122,7 +124,8 @@ describe('POST /api/v1/users', () => {
         expect(res).have.status(400);
         expect(res).to.be.an('object');
         expect(res.body).to.have.keys('status', 'error');
-        expect(res.body.error).to.deep.equal('Last name cannot begin with a number');
+        expect(res.body.error)
+          .to.deep.equal('Last name cannot contain number or special characters');
         expect(res.body.status).to.deep.equal('failed');
         done();
       });
@@ -156,7 +159,8 @@ describe('POST /api/v1/users', () => {
         expect(res).have.status(400);
         expect(res).to.be.an('object');
         expect(res.body).to.have.keys('status', 'error');
-        expect(res.body.error).to.deep.equal('Last name must be at least 2 characters long');
+        expect(res.body.error)
+          .to.deep.equal('Last name must be at least 2 characters long');
         expect(res.body.status).to.deep.equal('failed');
         done();
       });


### PR DESCRIPTION
### What does this PR do?
- Fixes validation on User name
- Displays a meaningful error message when numbers are used in first name or last name

### Description of Task to be completed?
- In the validation middleware, add regex to joi to allows the user name to contain numeric values
- Change the `First name and last name ` regex to display meaningful error message when user tries to use numbers for First and last name.

### How should this be manually tested?
In Postman or Swagger provide the following fields:
- firstName
- lastName
- userName,
- email
- password and
- confirmPassword
to successfully create a new user

### Any background context you want to provide:
Add `SECRET_KEY='your_key_here'` as an environment variable for token generation

### What are the relevant pivotal tracker stories?
[Fix validation on user name](https://www.pivotaltracker.com/story/show/#167780949)

### Screenshots? 
*In Postman*
<img width="1003" alt="Screen Shot 2019-08-08 at 13 51 05" src="https://user-images.githubusercontent.com/50101879/62703014-7a7bdd80-b9e8-11e9-85b2-f24fb0fc7b36.png">
<img width="1003" alt="Screen Shot 2019-08-08 at 13 52 08" src="https://user-images.githubusercontent.com/50101879/62703021-7fd92800-b9e8-11e9-902a-a195f00cd641.png">


