### PR TITLE
#167484601 Pagination support for articles

### DIFF
--- a/src/controllers/articleController.js
+++ b/src/controllers/articleController.js
@@ -75,7 +75,36 @@ class ArticleController {
    */
   static async getAllArticles(req, res) {
     try {
+      let page = parseInt(req.query.page, 10);
+      let limit = parseInt(req.query.limit, 10);
+      if (!page) {
+        page = 1;
+      }
+      if (!limit) {
+        limit = 10;
+      }
+      if (page < 1) {
+        page = 1;
+      }
+      if (limit < 1 || limit > 10) {
+        limit = 10;
+      }
+
+      const { count } = await Article.findAndCountAll();
+      if (!count) {
+        return res.status(404).json({
+          message: 'No articles found at the moment! please come back later'
+        });
+      }
+      const pages = Math.ceil(count / limit);
+      if (page > pages) {
+        page = pages;
+      }
+
+      const offset = (page - 1) * limit;
       const articles = await Article.findAll({
+        offset,
+        limit,
         order: [['createdAt', 'DESC']],
         include: [
           {
@@ -85,11 +114,6 @@ class ArticleController {
           }
         ]
       });
-      if (!articles.length) {
-        return res.status(404).json({
-          message: 'No articles found at the moment! please come back later'
-        });
-      }
       res.status(200).json({
         articles
       });

--- a/src/controllers/articleController.js
+++ b/src/controllers/articleController.js
@@ -75,7 +75,38 @@ class ArticleController {
    */
   static async getAllArticles(req, res) {
     try {
+      let page = parseInt(req.query.page, 10);
+      let limit = parseInt(req.query.limit, 10);
+      console.log(page);
+
+      if (!page) {
+        page = 1;
+      }
+      if (!limit) {
+        limit = 10;
+      }
+      if (page < 1) {
+        page = 1;
+      }
+      if (limit < 1 || limit > 10) {
+        limit = 10;
+      }
+
+      const { count } = await Article.findAndCountAll();
+      if (!count) {
+        return res.status(404).json({
+          message: 'No articles found at the moment! please come back later'
+        });
+      }
+      const pages = Math.ceil(count / limit);
+      if (page > pages) {
+        page = pages;
+      }
+
+      const offset = (page - 1) * limit;
       const articles = await Article.findAll({
+        offset,
+        limit,
         order: [['createdAt', 'DESC']],
         include: [
           {
@@ -85,11 +116,6 @@ class ArticleController {
           }
         ]
       });
-      if (!articles.length) {
-        return res.status(404).json({
-          message: 'No articles found at the moment! please come back later'
-        });
-      }
       res.status(200).json({
         articles
       });

--- a/src/tests/article.test.js
+++ b/src/tests/article.test.js
@@ -259,6 +259,71 @@ describe('POST AND GET /api/v1/articles', () => {
         done();
       });
   });
+  it('Should return articles if paginary page query is not specified', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles?limit=2')
+      .set('Authorization', userToken1)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(200);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.keys('articles');
+        done();
+      });
+  });
+  it('Should return articles if pagination limit query is not specified', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles?page=2')
+      .set('Authorization', userToken1)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(200);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.keys('articles');
+        done();
+      });
+  });
+  it('Should return articles if pagination page is negative', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles?page=-2')
+      .set('Authorization', userToken1)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(200);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.keys('articles');
+        done();
+      });
+  });
+  it('Should return articles if pagination limit is negative', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles?limit=-2')
+      .set('Authorization', userToken1)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(200);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.keys('articles');
+        done();
+      });
+  });
+  it('Should return articles if wrong values are provided for pagination', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/articles?page=one&limit=ten')
+      .set('Authorization', userToken1)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(200);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.keys('articles');
+        done();
+      });
+  });
   it('Should return a particluar article', (done) => {
     chai
       .request(app)


### PR DESCRIPTION
### What does this PR do?
- Adds pagination functionality when the user is retreiving articles

### Description of Task to be completed?
- Add two query parameters in on the getArticles route and specify the page number and the record limit
- Change the sequelize query to contain the offset and limit value for the paginated result

### How should this be manually tested?
In Postman or Swagger or any other tool of your choice visit these endpoints:
*POST*`/api/v1/articles?page=XXXX&limit=XXXX` to fetch all articles with the specified pagination

### What are the relevant pivotal tracker stories?
[Pagination support for articles](https://www.pivotaltracker.com/story/show/#167484601)

###Any background context you want to provide?
User this environment variable `ARTICLE_URL=http://localhost:3000/api/v1/articles`


### Screenshots? 
*In Postman*
<img width="1138" alt="Screen Shot 2019-08-27 at 13 37 08" src="https://user-images.githubusercontent.com/50101879/63768197-de027800-c8cf-11e9-9b60-5c5305596da2.png">

