### PR TITLE
#167484610 implemented article reading statistics 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,14 @@
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "build": "rm -rf build && babel -d ./build ./src -s",
     "start": "npm run build && npm run seed && node ./build/index.js",
-    "pretest": "cross-env NODE_ENV=test npm run down && NODE_ENV=test npm run migrate  && NODE_ENV=test npm run seed",
-    "test": "cross-env NODE_ENV=test nyc --reporter=text mocha  --require @babel/register --require @babel/polyfill  ./src/tests/*.js --timeout 50000 --exit",
+    "pretest": "cross-env NODE_ENV=test npm run createdb && npm run down && NODE_ENV=test npm run migrate  && NODE_ENV=test npm run seed",
+    "test": "cross-env NODE_ENV=test nyc --reporter=text mocha  --require @babel/register --require @babel/polyfill  ./src/tests/*.js --timeout 30000 --exit",
+    "posttest": "cross-env NODE_ENV=test npm run dropdb",
     "down": "cross-env NODE_ENV=test node_modules/.bin/sequelize db:migrate:undo",
     "migrate": "cross-env NODE_ENV=test node_modules/.bin/sequelize db:migrate",
-    "seed": "node_modules/.bin/sequelize db:seed:all"
+    "seed": "node_modules/.bin/sequelize db:seed:all",
+    "dropdb": "node_modules/.bin/sequelize db:drop",
+    "createdb": "node_modules/.bin/sequelize db:create"
   },
   "engines": {
     "node": "10.16.0"

--- a/src/controllers/articleController.js
+++ b/src/controllers/articleController.js
@@ -717,29 +717,21 @@ class ArticleController {
    * @returns {object} returns an object containing an article's statistics
    */
   static async readingStats(req, res) {
-    const authorIdentifier = req.userData.id;
-    const realAuthor = req.userData.username;
-    const proposedAuthor = req.params.author;
+    const slugId = req.params.articleSlug;
 
-    if (realAuthor !== proposedAuthor) {
-      return res.status(400).json({
-        message: 'Invalid username',
+    const findArticle = await Article.findOne({ where: { slug: slugId } });
+
+    if (!findArticle) {
+      return res.status(404).json({
+        message: 'Article not found'
       });
     }
 
-    const findArticles = await Article.findAll({ where: { authorId: authorIdentifier } });
+    const statistics = await Statistic.findOne({ where: { articleSlug: slugId } });
 
-    if (!findArticles.length) {
+    if (!statistics) {
       return res.status(404).json({
-        message: 'No reading statistics because you do not have any articles',
-      });
-    }
-
-    const statistics = await Statistic.findAll({ where: { authorId: authorIdentifier } });
-
-    if (!statistics.length) {
-      return res.status(404).json({
-        message: 'None of your articles has been read so far. Statistics not found'
+        message: 'The article has never been read so far'
       });
     }
 

--- a/src/helpers/articles/recordStats.js
+++ b/src/helpers/articles/recordStats.js
@@ -1,0 +1,20 @@
+import { Statistic } from '../../sequelize/models';
+
+const recordStatistics = async (article) => {
+  const { id, slug, authorId } = article;
+
+  const oldArticle = await Statistic.findOne({ where: { articleId: id } });
+
+  if (!oldArticle) {
+    await Statistic.create({
+      articleId: id,
+      articleSlug: slug,
+      authorId,
+      reads: 1
+    });
+  } else {
+    await Statistic.increment({ reads: 1 }, { where: { articleId: id } });
+  }
+};
+
+export default recordStatistics;

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -5,7 +5,9 @@ import bcrypt from 'bcrypt';
 config();
 
 const genToken = user => jwt.sign(
-  { id: user.id, email: user.email, role: user.role },
+  {
+    id: user.id, email: user.email, role: user.role, username: user.userName
+  },
   process.env.SECRET_KEY,
   { expiresIn: '1d' }
 );

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -71,5 +71,6 @@ router.patch('/api/v1/profiles/notifications/read/all', verifyToken, Notificatio
 router.post('/api/v1/bookmarks/:slug', [verifyToken, findUser], Bookmark.createBookmark);
 router.get('/api/v1/bookmarks', [verifyToken, findUser], Bookmark.getBookmarks);
 router.delete('/api/v1/bookmarks/:slug', [verifyToken, findUser], Bookmark.deleteBookmark);
+router.get('/api/v1/statistics/:author', verifyToken, Article.readingStats);
 
 export default router;

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -75,7 +75,7 @@ router.patch('/api/v1/profiles/notifications/read/all', verifyToken, Notificatio
 router.post('/api/v1/bookmarks/:slug', [verifyToken, findUser], Bookmark.createBookmark);
 router.get('/api/v1/bookmarks', [verifyToken, findUser], Bookmark.getBookmarks);
 router.delete('/api/v1/bookmarks/:slug', [verifyToken, findUser], Bookmark.deleteBookmark);
-router.get('/api/v1/reading-statistics/:author', verifyToken, Article.readingStats);
+router.get('/api/v1/articles/:articleSlug/statistics', verifyToken, Article.readingStats);
 router.post('/api/v1/articles/:articleSlug/reports', [verifyToken, Validation.reportValidation], Report.createReport);
 router.get('/api/v1/articles/reports/all', [verifyToken, checkAdmin], Report.getAllReports);
 router.get('/api/v1/articles/:articleSlug/reports', [verifyToken, checkAdmin], Report.getArticleReports);

--- a/src/sequelize/migrations/20190828164942-create-statistic.js
+++ b/src/sequelize/migrations/20190828164942-create-statistic.js
@@ -1,0 +1,32 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Statistics', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    articleId: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    articleSlug: {
+      type: Sequelize.STRING
+    },
+    authorId: {
+      type: Sequelize.INTEGER
+    },
+    reads: {
+      type: Sequelize.INTEGER
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Statistics')
+};

--- a/src/sequelize/models/User.js
+++ b/src/sequelize/models/User.js
@@ -80,6 +80,7 @@ export default (sequelize, DataTypes) => {
     User.hasMany(models.Reaction, { foreignKey: 'userId', as: 'LikerOrDisliker', onDelete: 'CASCADE' });
     User.hasMany(models.Comment, { foreignKey: 'userId', as: 'Commenter', onDelete: 'CASCADE' });
     User.hasMany(models.Bookmark, { foreignKey: 'userId', onDelete: 'CASCADE' });
+    User.hasMany(models.Statistic, { foreignKey: 'authorId', as: 'ArticleOwner', onDelete: 'CASCADE' });
   };
   return User;
 };

--- a/src/sequelize/models/article.js
+++ b/src/sequelize/models/article.js
@@ -64,6 +64,7 @@ module.exports = (sequelize, DataTypes) => {
     Article.hasMany(models.Reaction, { foreignKey: 'articleId', as: 'Article', onDelete: 'CASCADE' });
     Article.hasMany(models.Comment, { foreignKey: 'articleId', as: 'ArticleComment', onDelete: 'CASCADE' });
     Article.hasMany(models.Bookmark, { foreignKey: 'articleId', onDelete: 'CASCADE' });
+    Article.hasMany(models.Statistic, { foreignKey: 'articleId', as: 'ArticleStats', onDelete: 'CASCADE' });
   };
   return Article;
 };

--- a/src/sequelize/models/statistic.js
+++ b/src/sequelize/models/statistic.js
@@ -1,0 +1,36 @@
+export default (sequelize, DataTypes) => {
+  const Statistic = sequelize.define(
+    'Statistic',
+    {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: DataTypes.INTEGER
+      },
+      articleId: {
+        allowNull: false,
+        type: DataTypes.INTEGER
+      },
+      articleSlug: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
+      authorId: {
+        allowNull: false,
+        type: DataTypes.INTEGER
+      },
+      reads: {
+        type: DataTypes.INTEGER,
+        defaultValue: 0
+      },
+    }, {
+      timeStamps: true
+    }
+  );
+  Statistic.associate = (models) => {
+    Statistic.belongsTo(models.User, { foreignKey: 'authorId', as: 'ArticleOwner', onDelete: 'CASCADE' });
+    Statistic.belongsTo(models.Article, { foreignKey: 'articleId', as: 'ArticleStats', onDelete: 'CASCADE' });
+  };
+  return Statistic;
+};

--- a/src/tests/article.test.js
+++ b/src/tests/article.test.js
@@ -19,7 +19,6 @@ before(async () => {
 let userToken1 = '';
 let userToken2 = '';
 let articleSlug;
-let articleSlug2;
 let newArticleSlug;
 
 before(async () => {
@@ -245,158 +244,6 @@ describe('POST AND GET /api/v1/articles', () => {
         done();
       });
   });
-  it('Should create and return a second article', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/articles')
-      .set('Authorization', userToken1)
-      .field(dummyArticle.validArticle)
-      .attach('image', fs.readFileSync('src/tests/dummyData/avatar.jpg'), 'avatar.jpg')
-      .end((err, res) => {
-        articleSlug = res.body.article.slug;
-        if (err) done(err);
-        expect(res).have.status(201);
-        expect(res.body.article)
-          .to.have.property('images');
-        expect(res.body).to.have.key('article');
-        articleSlug2 = res.body.article.slug;
-        articleId = res.body.article.id;
-        done();
-      });
-  });
-  it('Should comment on the article', (done) => {
-    chai
-      .request(app)
-      .post(`/api/v1/articles/${articleSlug2}/comments`)
-      .set('Authorization', userToken1)
-      .send({ comment: 'This story is cool!' })
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(201);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message', 'articleComment');
-        expect(res.body.message).to.deep.equal('You have commented on the article');
-        expect(res.body.articleComment).to.be.an('object');
-        done();
-      });
-  });
-  it('Should retrieve comments of the article', (done) => {
-    chai
-      .request(app)
-      .get(`/api/v1/articles/${articleSlug2}/comments`)
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message', 'comments');
-        expect(res.body.message).to.deep.equal('Comments retrieved');
-        expect(res.body.comments).to.be.an('array');
-        done();
-      });
-  });
-  it('Should update the comment of the article', (done) => {
-    chai
-      .request(app)
-      .patch(`/api/v1/articles/${articleSlug2}/comments/1`)
-      .set('Authorization', userToken1)
-      .send({ comment: 'I have changed my comment!' })
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message', 'updatedComment');
-        expect(res.body.message).to.deep.equal('Comment updated');
-        expect(res.body.updatedComment).to.be.an('object');
-        done();
-      });
-  });
-  it('Should not update the comment if it cannot be found', (done) => {
-    chai
-      .request(app)
-      .patch(`/api/v1/articles/${articleSlug2}/comments/10000`)
-      .set('Authorization', userToken1)
-      .send({ comment: 'I have changed my comment!' })
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(404);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message');
-        expect(res.body.message).to.deep.equal('Comment cannot be found');
-        done();
-      });
-  });
-  it('Should not comment on the article if it does not exist', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/articles/1/comments')
-      .set('Authorization', userToken1)
-      .send({ comment: 'This story is cool!' })
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(404);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message');
-        expect(res.body.message).to.deep.equal('Article not found');
-        done();
-      });
-  });
-  it('Should not comment on the article if comment is not provided', (done) => {
-    chai
-      .request(app)
-      .post(`/api/v1/articles/${articleSlug}/comments`)
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(400);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('error');
-        expect(res.body.error).to.deep.equal('Comment is required');
-        done();
-      });
-  });
-  it('Should delete the comment of the article', (done) => {
-    chai
-      .request(app)
-      .delete(`/api/v1/articles/${articleSlug2}/comments/1`)
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message');
-        expect(res.body.message).to.deep.equal('Comment deleted');
-        done();
-      });
-  });
-  it('Should not delete the comment if it cannot be found', (done) => {
-    chai
-      .request(app)
-      .delete(`/api/v1/articles/${articleSlug2}/comments/1`)
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(404);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message');
-        expect(res.body.message).to.deep.equal('Comment cannot be found');
-        done();
-      });
-  });
-  it('Should not retrieve comments because the article has none', (done) => {
-    chai
-      .request(app)
-      .get(`/api/v1/articles/${articleSlug2}/comments`)
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(404);
-        expect(res).to.be.an('object');
-        expect(res.body).to.have.keys('message');
-        expect(res.body.message).to.deep.equal('The article has no comments at the moment');
-        done();
-      });
-  });
   it('Should return all avaiable articles', (done) => {
     chai
       .request(app)
@@ -408,109 +255,6 @@ describe('POST AND GET /api/v1/articles', () => {
         expect(res).to.be.an('object');
         expect(res.body)
           .to.have.keys('articles', 'firstPage', 'lastPage', 'currentPage', 'nextPage', 'previousPage');
-        done();
-      });
-  });
-  it('Should return the previous page', (done) => {
-    chai
-      .request(app)
-      .get('/api/v1/articles?page=2&limit=1')
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body)
-          .to.have.keys('articles', 'firstPage', 'lastPage', 'currentPage', 'nextPage', 'previousPage');
-        expect(res.body.previousPage).to.deep.equal('http://localhost:3000/api/v1/articles?page=1&limit=1');
-        done();
-      });
-  });
-  it('Should return articles if paginary page query is not specified', (done) => {
-    chai
-      .request(app)
-      .get('/api/v1/articles?limit=2')
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body)
-          .to.have.keys('articles', 'firstPage', 'lastPage', 'currentPage', 'nextPage', 'previousPage');
-        done();
-      });
-  });
-  it('Should return articles if pagination limit query is not specified', (done) => {
-    chai
-      .request(app)
-      .get('/api/v1/articles?page=2')
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body)
-          .to.have.keys('articles', 'firstPage', 'lastPage', 'currentPage', 'nextPage', 'previousPage');
-        done();
-      });
-  });
-  it('Should return articles if pagination page is negative', (done) => {
-    chai
-      .request(app)
-      .get('/api/v1/articles?page=-2')
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body)
-          .to.have.keys('articles', 'firstPage', 'lastPage', 'currentPage', 'nextPage', 'previousPage');
-        done();
-      });
-  });
-  it('Should return articles if pagination limit is negative', (done) => {
-    chai
-      .request(app)
-      .get('/api/v1/articles?limit=-2')
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body)
-          .to.have.keys('articles', 'firstPage', 'lastPage', 'currentPage', 'nextPage', 'previousPage');
-        done();
-      });
-  });
-  it('Should return articles if wrong values are provided for pagination', (done) => {
-    chai
-      .request(app)
-      .get('/api/v1/articles?page=one&limit=ten')
-      .set('Authorization', userToken1)
-      .end((err, res) => {
-        if (err) done(err);
-        expect(res).have.status(200);
-        expect(res).to.be.an('object');
-        expect(res.body)
-          .to.have.keys('articles', 'firstPage', 'lastPage', 'currentPage', 'nextPage', 'previousPage');
-        expect(res.body.articles).to.be.an('array');
-        expect(res.body.articles[0]).to.have.keys(
-          'id',
-          'slug',
-          'title',
-          'description',
-          'body',
-          'category',
-          'tagList',
-          'images',
-          'authorId',
-          'likes',
-          'dislikes',
-          'createdAt',
-          'updatedAt',
-          'author',
-          'readTime'
-        );
         done();
       });
   });
@@ -815,6 +559,65 @@ describe('POST /api/v1/articles/{id}/rate', () => {
         expect(res).have.status(400);
         expect(res).to.be.an('object');
         expect(res.body.error).to.deep.equal('id must be a number');
+        done();
+      });
+  });
+});
+
+//  sharing article
+describe('POST api/v1/articles/:slug/share/:option', () => {
+  it('Should share the post on gmail', (done) => {
+    chai.request(app)
+      .post(`/api/v1/articles/${newArticleSlug}/share/gmail`)
+      .set('Authorization', userToken1)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(201);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.key('message', 'share');
+        expect(res.body.share).to.be.an('object');
+        expect(res.body.message).to.deep.equal('Successfully shared the article on gmail');
+        done();
+      });
+  });
+  it('Should share the post on twitter', (done) => {
+    chai.request(app)
+      .post(`/api/v1/articles/${newArticleSlug}/share/twitter`)
+      .set('Authorization', userToken2)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(201);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.key('message', 'share');
+        expect(res.body.share).to.be.an('object');
+        expect(res.body.message).to.deep.equal('Successfully shared the article on twitter');
+        done();
+      });
+  });
+  it('Should share the post on facebook', (done) => {
+    chai.request(app)
+      .post(`/api/v1/articles/${newArticleSlug}/share/facebook`)
+      .set('Authorization', userToken2)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(201);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.key('message', 'share');
+        expect(res.body.share).to.be.an('object');
+        expect(res.body.message).to.deep.equal('Successfully shared the article on facebook');
+        done();
+      });
+  });
+  it('Should not share the article if it is not found', (done) => {
+    chai.request(app)
+      .post('/api/v1/articles/this-article-is-not-valid/share/gmail')
+      .set('Authorization', userToken1)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(404);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.key('error');
+        expect(res.body.error).to.deep.equal('article not found');
         done();
       });
   });

--- a/src/tests/article.test.js
+++ b/src/tests/article.test.js
@@ -22,6 +22,7 @@ let userToken3;
 let userToken4;
 let articleSlug;
 let newArticleSlug;
+const invalidArticleSlug = 'something-new-w2zjzvm6o5sgad456';
 
 before(async () => {
   await Follow.create(dummyUser.validFollower);
@@ -289,17 +290,17 @@ describe('POST AND GET /api/v1/articles', () => {
         done();
       });
   });
-  it('Should not retrieve reading statistics because the author\'s articles have never been read', (done) => {
+  it('Should not retrieve reading statistics because the article will have never been read so far', (done) => {
     chai
       .request(app)
-      .get('/api/v1/reading-statistics/kate')
+      .get(`/api/v1/articles/${articleSlug}/statistics`)
       .set('Authorization', userToken4)
       .end((err, res) => {
         if (err) done(err);
         expect(res).have.status(404);
         expect(res).to.be.an('object');
         expect(res.body).to.have.keys('message');
-        expect(res.body.message).to.deep.equal('None of your articles has been read so far. Statistics not found');
+        expect(res.body.message).to.deep.equal('The article has never been read so far');
         done();
       });
   });
@@ -395,7 +396,7 @@ describe('POST AND GET /api/v1/articles', () => {
   it('Should retrieve reading statistics', (done) => {
     chai
       .request(app)
-      .get('/api/v1/reading-statistics/super-admin')
+      .get(`/api/v1/articles/${articleSlug}/statistics`)
       .set('Authorization', userToken1)
       .end((err, res) => {
         if (err) done(err);
@@ -403,22 +404,22 @@ describe('POST AND GET /api/v1/articles', () => {
         expect(res).to.be.an('object');
         expect(res.body).to.have.keys('message', 'statistics');
         expect(res.body.message).to.deep.equal('Reading statistics retrieved');
-        expect(res.body.statistics).to.be.an('array');
+        expect(res.body.statistics).to.be.an('object');
         done();
       });
   });
 });
-it('Should not retrieve reading statistics because the author has no article', (done) => {
+it('Should not retrieve reading statistics because the articles does not exist', (done) => {
   chai
     .request(app)
-    .get('/api/v1/reading-statistics/cyubahiro')
+    .get(`/api/v1/articles/${invalidArticleSlug}/statistics`)
     .set('Authorization', userToken3)
     .end((err, res) => {
       if (err) done(err);
       expect(res).have.status(404);
       expect(res).to.be.an('object');
       expect(res.body).to.have.keys('message');
-      expect(res.body.message).to.deep.equal('No reading statistics because you do not have any articles');
+      expect(res.body.message).to.deep.equal('Article not found');
       done();
     });
 });

--- a/swagger.json
+++ b/swagger.json
@@ -1714,12 +1714,12 @@
                 }
             }
         },
-        "/api/v1/reading-statistics/{username}": {
+        "/api/v1/articles/{articleSlug}/statistics": {
             "get": {
                 "tags": [
                     "Articles"
                 ],
-                "summary": "Retrieve author's articles' reading statistics",
+                "summary": "Retrieve an article's reading statistics",
                 "produces": [
                     "application/json"
                 ],
@@ -1731,9 +1731,9 @@
                         "required": true
                     },
                     {
-                        "name": "username",
+                        "name": "articleSlug",
                         "in": "path",
-                        "description": "Author's username",
+                        "description": "A slug of an article",
                         "required": true,
                         "type": "string"
                     }
@@ -1743,7 +1743,7 @@
                         "description": "Reading statistics retrieved"
                     },
                     "404": {
-                        "description": "Reading statistics not found"
+                        "description": "Reading statistics/Article not found"
                     },
                     "401": {
                         "description": "Unauthorized Access"


### PR DESCRIPTION
#### What does this PR do?
It implements the approach of being able to retrieve articles' reading statistics.

#### Description of Task to be done?
1. Adding code to record a specific article's retrieval.
2. Adding a route for retrieving an author's articles' reading statistics.
3. Adding a controller for retrieving an authors' articles' reading statistics.
4. Adding tests for reading statistics.

#### Screenshots
<img width="1384" alt="Screen Shot 2019-09-02 at 21 46 26" src="https://user-images.githubusercontent.com/34879554/64131777-2c7dae00-cdcb-11e9-89c4-926269f9be07.png">

<img width="1133" alt="Screen Shot 2019-09-02 at 21 47 18" src="https://user-images.githubusercontent.com/34879554/64131787-43240500-cdcb-11e9-8557-4982f4fcd82b.png">


#### How should this be manually tested?
1. Clone this branch.
2. Do **npm install**.
4. Do **npm start**
5. Create an article.
6. Check how many times it has been read with the following endpoint: **/api/v1/articles/{articleSlug}/statistics**
7. Retrieve the article that you have created  with the following endpoint: **/api/v1/articles/{articleSlug}**
8. Re-Check how many times it has been read with the following endpoint: **/api/v1/articles/{articleSlug}/statistics** and you will find that it has been read once. Therefore, the more you retrieve it, the more reads increase**