### PR TITLE
#167484604 Fix article filtering functionality bug

### DIFF
--- a/src/helpers/articles/articleHelper.js
+++ b/src/helpers/articles/articleHelper.js
@@ -60,9 +60,9 @@ const queryFilterer = (title, author, tags) => {
   if (!author) delete queries.query.where;
   if (!title) delete queries.query.title;
   if (!tags) delete queries.query.tagList;
+
   return {
-    where: (title || author || tags)
-      ? { ...queries.query } : undefined
+    where: { ...queries.query }
   };
 };
 


### PR DESCRIPTION
### What does this PR do?
Changes the `getArticles` endpoint from fetching clocked articles

### Description of Task to be completed?
- Change the `articleelper.js` to exclude the `undefined` value in the where clause

You can search articles with the following query parameters:
- title
- author
- tags
- limit
- page

### How should this be manually tested?
In Postman or Swagger or any other tool of your choice visit these endpoints:
*GET*`/api/v1/articles?title=XXXval&author=XXXval&tagList=XXXval` To filter fetching articles

### What are the relevant pivotal tracker stories?
[search Functionality and Custom filtering based on parameters](https://www.pivotaltracker.com/story/show/#167484604)


### Screenshots? 
*In Postman*
<img width="763" alt="Screen Shot 2019-09-06 at 01 57 14" src="https://user-images.githubusercontent.com/50101879/64391639-bfc41700-d049-11e9-85dd-148275001770.png">
